### PR TITLE
Implement initial auth flow with Supabase

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,10 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "supabaseUrl": "YOUR_SUPABASE_URL",
+      "supabaseAnonKey": "YOUR_SUPABASE_ANON_KEY"
     }
   }
 }

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { supabase } from '@/src/lib/supabase';
+import { useDispatch } from 'react-redux';
+import { setUser } from '@/src/store/authSlice';
+import { router } from 'expo-router';
+
+export default function SignInScreen() {
+  const dispatch = useDispatch();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSignIn = async () => {
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (!error && data.session) {
+      dispatch(setUser({ id: data.user.id, email: data.user.email! }));
+      router.replace('/(tabs)/');
+    } else {
+      console.log(error);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button title="Sign In" onPress={handleSignIn} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { supabase } from '@/src/lib/supabase';
+import { useDispatch } from 'react-redux';
+import { setUser } from '@/src/store/authSlice';
+import { router } from 'expo-router';
+
+export default function SignUpScreen() {
+  const dispatch = useDispatch();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSignUp = async () => {
+    const { data, error } = await supabase.auth.signUp({ email, password });
+    if (!error && data.session) {
+      dispatch(setUser({ id: data.user.id, email: data.user.email! }));
+      router.replace('/(tabs)/');
+    } else {
+      console.log(error);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={styles.input}
+      />
+      <Button title="Create Account" onPress={handleSignUp} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,10 @@
+import { Tabs } from 'expo-router';
+
+export default function TabLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen name="home" options={{ title: 'Home' }} />
+      <Tabs.Screen name="profile" options={{ title: 'Profile' }} />
+    </Tabs>
+  );
+}

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,0 +1,17 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Home Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,0 +1,24 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/src/store/store';
+
+export default function ProfileScreen() {
+  const user = useSelector((state: RootState) => state.auth.user);
+
+  return (
+    <View style={styles.container}>
+      <Text>Profile Screen</Text>
+      {user && (
+        <Text>{user.email}</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,11 @@
 import { Stack } from "expo-router";
+import { Provider } from "react-redux";
+import { store } from "@/src/store/store";
 
 export default function RootLayout() {
-  return <Stack />;
+  return (
+    <Provider store={store}>
+      <Stack screenOptions={{ headerShown: false }} />
+    </Provider>
+  );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,21 +1,5 @@
-import { StyleSheet, Text, View } from "react-native";
+import { Redirect } from 'expo-router';
 
 export default function Index() {
-  return (
-    <View
-      style={styles.container}
-    >
-      <Text>Hello test this is working</Text>
-    </View>
-  );
-  
+  return <Redirect href="/(auth)/sign-in" />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: "#25292e",
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@supabase/supabase-js": "^2.39.3",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+import Constants from 'expo-constants';
+
+const supabaseUrl = Constants.expoConfig?.extra?.supabaseUrl as string;
+const supabaseAnonKey = Constants.expoConfig?.extra?.supabaseAnonKey as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface User {
+  id: string;
+  email: string;
+}
+
+interface AuthState {
+  user: User | null;
+}
+
+const initialState: AuthState = {
+  user: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setUser(state, action: PayloadAction<User | null>) {
+      state.user = action.payload;
+    },
+  },
+});
+
+export const { setUser } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './authSlice';
+
+export const store = configureStore({
+  reducer: {
+    auth: authReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+


### PR DESCRIPTION
## Summary
- wire up expo config with Supabase credentials
- add dependencies for Supabase and Redux
- set up Redux store and auth slice
- add Supabase client helper
- create sign-in and sign-up screens
- create tab navigator with Home and Profile
- wrap the app in Redux `Provider`

## Testing
- `npm run lint` *(fails: expo not found)*