### PR TITLE
Update Redux packages for React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,10 @@
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.10.0",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "@supabase/supabase-js": "^2.39.3",
+        "@reduxjs/toolkit": "^2.2.0",
+        "react-redux": "^9.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "@supabase/supabase-js": "^2.39.3",
-    "@reduxjs/toolkit": "^1.9.5",
-    "react-redux": "^9.0.0"
+    "@reduxjs/toolkit": "^2.2.0",
+    "react-redux": "^9.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- bump `@reduxjs/toolkit` to `^2.2.0`
- bump `react-redux` to `^9.1.2`
- update lockfile to reflect new package versions

## Testing
- `npm install --offline` *(fails: cache miss)*
- `npm run lint` *(fails: expo not found)*